### PR TITLE
feat(minio): enhance file upload handling and testing

### DIFF
--- a/minio/minio.go
+++ b/minio/minio.go
@@ -111,9 +111,20 @@ func (m *Minio) UploadFileByReader(
 	contentType string,
 	length int64,
 ) error {
+	if contentType == "" {
+		buffer := make([]byte, 512)
+		n, err := reader.Read(buffer)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		contentType = http.DetectContentType(buffer[:n])
+		reader = io.MultiReader(bytes.NewReader(buffer[:n]), reader)
+	}
+
 	opts := minio.PutObjectOptions{
 		ContentType: contentType,
 	}
+
 	// Upload the zip file with FPutObject
 	_, err := m.client.PutObject(
 		ctx,


### PR DESCRIPTION
- Add content type detection in `UploadFileByReader` if not provided
- Add a new test `TestUploadFileByReader` to verify file upload functionality using a reader
- Ensure the test checks file existence and content after upload
- Add cleanup logic to terminate the Minio container after the test